### PR TITLE
enable auto_detect_line_endings ini setting

### DIFF
--- a/rs-csv-importer.php
+++ b/rs-csv-importer.php
@@ -147,6 +147,8 @@ class RS_CSV_Importer extends WP_Importer {
 
 	// process parse csv ind insert posts
 	function process_posts() {
+		ini_set("auto_detect_line_endings", true);
+
 		$h = new RS_CSV_Helper;
 
 		$handle = $h->fopen($this->file, 'r');


### PR DESCRIPTION
Per the PHP doc (http://php.net/manual/en/filesystem.configuration.php):
"This enables PHP to interoperate with Macintosh systems, but defaults to Off, as there is a very small performance penalty when detecting the EOL conventions for the first line, and also because people using carriage-returns as item separators under Unix systems would experience non-backwards-compatible behaviour. "

Enabling the setting in this plugin makes it possible to upload CSVs that fail without it. The "very small performance penalty" occurs only once per import, so it's negligible in this context. 
